### PR TITLE
Update login.py

### DIFF
--- a/pytds/login.py
+++ b/pytds/login.py
@@ -98,11 +98,11 @@ class NtlmAuth(object):
     :param password: User password
     :type password: str
     """
-    def __init__(self, user_name, password):
+    def __init__(self, user_name, password, domain='workspace'):
         if '\\' in user_name:
             self._domain, self._user = user_name.split('\\', 1)
         else:
-            self._domain = 'workspace'
+            self._domain = domain
             self._user = user_name
         self._password = password
 


### PR DESCRIPTION
I added a domain keyword argument to NtlmAuth. NTLM authorization fails on MacOS unless this value is updated. The change preserves its current behavior while allowing users to override the default without modifying the library source-code.